### PR TITLE
Add Laravel Product API example

### DIFF
--- a/LaravelProductAPI/README.md
+++ b/LaravelProductAPI/README.md
@@ -1,0 +1,5 @@
+# Laravel Product API Example
+
+This example demonstrates a minimal Laravel-style API to register products. When a product with an existing name is added, the stock is updated and purchase details are stored.
+
+Folder structure mimics a typical Laravel project but is simplified for demonstration.

--- a/LaravelProductAPI/app/Http/Controllers/Controller.php
+++ b/LaravelProductAPI/app/Http/Controllers/Controller.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Controller as BaseController;
+
+class Controller extends BaseController
+{
+    // Base controller for other controllers
+}

--- a/LaravelProductAPI/app/Http/Controllers/ProductController.php
+++ b/LaravelProductAPI/app/Http/Controllers/ProductController.php
@@ -1,0 +1,34 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+
+class ProductController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+            'unit' => 'required|string',
+            'stock' => 'required|numeric',
+            'date' => 'required|date',
+            'price' => 'required|numeric',
+            'supplier' => 'required|string',
+            'invoice_path' => 'required|string',
+        ]);
+
+        $product = Product::firstOrNew(['name' => $data['name']]);
+
+        $product->unit = $data['unit'];
+        $product->stock = ($product->exists ? $product->stock : 0) + $data['stock'];
+        $product->last_purchase_date = $data['date'];
+        $product->last_price = $data['price'];
+        $product->last_supplier = $data['supplier'];
+        $product->invoice_path = $data['invoice_path'];
+
+        $product->save();
+
+        return response()->json($product, 201);
+    }
+}

--- a/LaravelProductAPI/app/Models/Product.php
+++ b/LaravelProductAPI/app/Models/Product.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'unit',
+        'stock',
+        'last_purchase_date',
+        'last_price',
+        'last_supplier',
+        'invoice_path',
+    ];
+}

--- a/LaravelProductAPI/database/migrations/2024_01_01_000000_create_products_table.php
+++ b/LaravelProductAPI/database/migrations/2024_01_01_000000_create_products_table.php
@@ -1,0 +1,26 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('unit');
+            $table->float('stock')->default(0);
+            $table->date('last_purchase_date')->nullable();
+            $table->decimal('last_price', 10, 2)->nullable();
+            $table->string('last_supplier')->nullable();
+            $table->string('invoice_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/LaravelProductAPI/routes/api.php
+++ b/LaravelProductAPI/routes/api.php
@@ -1,0 +1,5 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ProductController;
+
+Route::post('/products', [ProductController::class, 'store']);


### PR DESCRIPTION
## Summary
- create a simple Laravel-style Product API example
- include a migration, model, controller, routes and README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840406574048324bdb88c7994ec4bc9